### PR TITLE
Fix for non-working log_on_error due to bad scope of exceptions. Remove unused value from log_exception

### DIFF
--- a/logdecorator/decorator.py
+++ b/logdecorator/decorator.py
@@ -170,5 +170,5 @@ class log_exception(log_on_error):
                          exception_format_variable=exception_format_variable)
 
     @staticmethod
-    def log(logger: Logger, log_level: Union[str, int], msg: str) -> None:
+    def log(logger: Logger, msg: str) -> None:
         logger.exception(msg)

--- a/logdecorator/decorator.py
+++ b/logdecorator/decorator.py
@@ -145,7 +145,7 @@ class log_on_error(LoggingDecorator):
     def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
         try:
             return super().execute(fn, *args, **kwargs)
-        except Exception as e:
+        except BaseException as e:
             self.on_error(fn, e, *args, **kwargs)
 
     def on_error(self, fn: FunctionType, exception: Exception, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
Hi. I just recognized that @log_on_error throws an exception and doesn't give any log. So I found what's the problem - Exception, so I changed it to the BaseException. After that it catches the exception from function and outputs the log msg :)