### PR TITLE
Refactor #21 Replace FunctionType with Callable

### DIFF
--- a/logdecorator/asyncio.py
+++ b/logdecorator/asyncio.py
@@ -1,20 +1,22 @@
 from functools import wraps
-from types import FunctionType
-from typing import Callable, Any
+from typing import Callable, Any, TypeVar, ParamSpec
 
 from logdecorator import log_on_start, log_on_end, log_on_error, log_exception
 from logdecorator.decorator import DecoratorMixin
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
 
 class AsyncDecoratorMixin(DecoratorMixin):
 
-    async def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         return await fn(*args, **kwargs)
 
-    def __call__(self, fn: FunctionType) -> Callable[..., Any]:
+    def __call__(self, fn: Callable[P, T]) -> Callable[P, T]:
 
         @wraps(fn)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             return await self.execute(fn, *args, **kwargs)
 
         return wrapper
@@ -22,23 +24,22 @@ class AsyncDecoratorMixin(DecoratorMixin):
 
 class async_log_on_start(AsyncDecoratorMixin, log_on_start):
 
-    async def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         self._do_logging(fn, *args, **kwargs)
         return await super().execute(fn, *args, **kwargs)
 
 
 class async_log_on_end(AsyncDecoratorMixin, log_on_end):
 
-    async def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         result = await super().execute(fn, *args, **kwargs)
         self._do_logging(fn, result, *args, **kwargs)
-
         return result
 
 
 class async_log_on_error(AsyncDecoratorMixin, log_on_error):
 
-    async def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return await super().execute(fn, *args, **kwargs)
         except Exception as e:
@@ -47,5 +48,5 @@ class async_log_on_error(AsyncDecoratorMixin, log_on_error):
 
 class async_log_exception(async_log_on_error, log_exception):
 
-    async def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         return await super().execute(fn, *args, **kwargs)

--- a/logdecorator/asyncio.py
+++ b/logdecorator/asyncio.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Any, TypeVar, ParamSpec, Awaitable, cast
+from typing import Callable, Any, TypeVar, ParamSpec, Awaitable, cast, Optional
 
 from logdecorator import log_on_start, log_on_end, log_on_error, log_exception
 from logdecorator.decorator import DecoratorMixin
@@ -10,28 +10,28 @@ T = TypeVar("T")
 
 class AsyncDecoratorMixin(DecoratorMixin):
 
-    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> Optional[T]: # type: ignore[override]
         return await fn(*args, **kwargs)
 
-    def __call__(self, fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    def __call__(self, fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[Optional[T]]]: # type: ignore[override]
 
         @wraps(fn)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
             return await self.execute(fn, *args, **kwargs)
 
-        return cast(Callable[P, Awaitable[T]], wrapper)
+        return cast(Callable[P, Awaitable[Optional[T]]], wrapper)
 
 
 class async_log_on_start(AsyncDecoratorMixin, log_on_start):
 
-    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[Optional[T]]], *args: P.args, **kwargs: P.kwargs) -> Optional[T]: # type: ignore[override]
         self._do_logging(fn, *args, **kwargs)
         return await super().execute(fn, *args, **kwargs)
 
 
 class async_log_on_end(AsyncDecoratorMixin, log_on_end):
 
-    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[Optional[T]]], *args: P.args, **kwargs: P.kwargs) -> Optional[T]: # type: ignore[override]
         result = await super().execute(fn, *args, **kwargs)
         self._do_logging(fn, result, *args, **kwargs)
         return result
@@ -39,14 +39,15 @@ class async_log_on_end(AsyncDecoratorMixin, log_on_end):
 
 class async_log_on_error(AsyncDecoratorMixin, log_on_error):
 
-    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[Optional[T]]], *args: P.args, **kwargs: P.kwargs) -> Optional[T]: # type: ignore[override]
         try:
             return await super().execute(fn, *args, **kwargs)
         except Exception as e:
             self.on_error(fn, e, *args, **kwargs)
+            return None
 
 
 class async_log_exception(async_log_on_error, log_exception):
 
-    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[Optional[T]]], *args: P.args, **kwargs: P.kwargs) -> Optional[T]: # type: ignore[override]
         return await super().execute(fn, *args, **kwargs)

--- a/logdecorator/asyncio.py
+++ b/logdecorator/asyncio.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Any, TypeVar, ParamSpec
+from typing import Callable, Any, TypeVar, ParamSpec, Awaitable, cast
 
 from logdecorator import log_on_start, log_on_end, log_on_error, log_exception
 from logdecorator.decorator import DecoratorMixin
@@ -10,28 +10,28 @@ T = TypeVar("T")
 
 class AsyncDecoratorMixin(DecoratorMixin):
 
-    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
         return await fn(*args, **kwargs)
 
-    def __call__(self, fn: Callable[P, T]) -> Callable[P, T]:
+    def __call__(self, fn: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
 
         @wraps(fn)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             return await self.execute(fn, *args, **kwargs)
 
-        return wrapper
+        return cast(Callable[P, Awaitable[T]], wrapper)
 
 
 class async_log_on_start(AsyncDecoratorMixin, log_on_start):
 
-    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
         self._do_logging(fn, *args, **kwargs)
         return await super().execute(fn, *args, **kwargs)
 
 
 class async_log_on_end(AsyncDecoratorMixin, log_on_end):
 
-    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
         result = await super().execute(fn, *args, **kwargs)
         self._do_logging(fn, result, *args, **kwargs)
         return result
@@ -39,7 +39,7 @@ class async_log_on_end(AsyncDecoratorMixin, log_on_end):
 
 class async_log_on_error(AsyncDecoratorMixin, log_on_error):
 
-    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return await super().execute(fn, *args, **kwargs)
         except Exception as e:
@@ -48,5 +48,5 @@ class async_log_on_error(AsyncDecoratorMixin, log_on_error):
 
 class async_log_exception(async_log_on_error, log_exception):
 
-    async def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    async def execute(self, fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:
         return await super().execute(fn, *args, **kwargs)

--- a/logdecorator/decorator.py
+++ b/logdecorator/decorator.py
@@ -2,20 +2,22 @@ import inspect
 import logging
 from functools import wraps
 from logging import Logger, Handler
-from types import FunctionType
-from typing import Callable, Any, Dict, Tuple, Optional, Union, Type
+from typing import Callable, Any, Dict, Tuple, Optional, Union, Type, TypeVar, ParamSpec
 from warnings import warn
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 class DecoratorMixin(object):
 
-    def execute(self, fn: FunctionType, *args: Tuple[Any], **kwargs: Any) -> Any:
+    def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         return fn(*args, **kwargs)
 
-    def __call__(self, fn: FunctionType) -> Callable[..., Any]:
+    def __call__(self, fn: Callable[P, T]) -> Callable[P, T]:
 
         @wraps(fn)
-        def wrapper(*args: Tuple[Any], **kwargs: Any) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             return self.execute(fn, *args, **kwargs)
 
         return wrapper
@@ -45,7 +47,7 @@ class LoggingDecorator(DecoratorMixin):
     def log(logger: Logger, log_level: int, msg: str) -> None:
         logger.log(log_level, msg)
 
-    def get_logger(self, fn: FunctionType) -> Logger:
+    def get_logger(self, fn: Callable[P, T]) -> Logger:
         if self._logger is None:
             self._logger = logging.getLogger(fn.__module__)
 
@@ -55,7 +57,7 @@ class LoggingDecorator(DecoratorMixin):
         return self._logger
 
     @staticmethod
-    def build_extensive_kwargs(fn: FunctionType, *args: Tuple[Any], **kwargs: Any) -> Dict[str, Any]:
+    def build_extensive_kwargs(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Dict[str, Any]:
         function_signature = inspect.signature(fn)
         bound_arguments = function_signature.bind_partial(*args, **kwargs)
 
@@ -67,7 +69,7 @@ class LoggingDecorator(DecoratorMixin):
 
         return extensive_kwargs
 
-    def build_msg(self, fn: FunctionType, fn_args: Any, fn_kwargs: Any,
+    def build_msg(self, fn: Callable[P, T], fn_args: Any, fn_kwargs: Any,
                   **extra: Any) -> str:
         format_kwargs = self.build_extensive_kwargs(fn, *fn_args, **fn_kwargs)
         extra[self.callable_format_variable] = fn
@@ -78,13 +80,13 @@ class LoggingDecorator(DecoratorMixin):
 
 class log_on_start(LoggingDecorator):
 
-    def _do_logging(self, fn: FunctionType, *args: Any, **kwargs: Any) -> None:
+    def _do_logging(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> None:
         logger = self.get_logger(fn)
         msg = self.build_msg(fn, fn_args=args, fn_kwargs=kwargs)
 
         self.log(logger, self.log_level, msg)
 
-    def execute(self, fn: FunctionType, *args: Tuple[Any], **kwargs: Any) -> Any:
+    def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         self._do_logging(fn, *args, **kwargs)
         return super().execute(fn, *args, **kwargs)
 
@@ -98,7 +100,7 @@ class log_on_end(LoggingDecorator):
                          callable_format_variable=callable_format_variable)
         self.result_format_variable = result_format_variable
 
-    def _do_logging(self, fn: FunctionType, result: Any, *args: Tuple[Any], **kwargs: Any) -> None:
+    def _do_logging(self, fn: Callable[P, T], result: T, *args: P.args, **kwargs: P.kwargs) -> None:
         logger = self.get_logger(fn)
         extra = {
             self.result_format_variable: result
@@ -107,7 +109,7 @@ class log_on_end(LoggingDecorator):
 
         self.log(logger, self.log_level, msg)
 
-    def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         result = super().execute(fn, *args, **kwargs)
         self._do_logging(fn, result, *args, **kwargs)
 
@@ -132,7 +134,7 @@ class log_on_error(LoggingDecorator):
         self.reraise = reraise
         self.exception_format_variable = exception_format_variable
 
-    def _do_logging(self, fn: FunctionType, exception: Exception, *args: Any, **kwargs: Any
+    def _do_logging(self, fn: Callable[P, T], exception: Exception, *args: P.args, **kwargs: P.kwargs
                     ) -> None:
         logger = self.get_logger(fn)
         extra: Dict[str, Any] = {
@@ -142,13 +144,13 @@ class log_on_error(LoggingDecorator):
 
         self.log(logger, self.log_level, msg)
 
-    def execute(self, fn: FunctionType, *args: Any, **kwargs: Any) -> Any:
+    def execute(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return super().execute(fn, *args, **kwargs)
         except Exception as e:
             self.on_error(fn, e, *args, **kwargs)
 
-    def on_error(self, fn: FunctionType, exception: Exception, *args: Any, **kwargs: Any) -> None:
+    def on_error(self, fn: Callable[P, T], exception: Exception, *args: P.args, **kwargs: P.kwargs) -> None:
         try:
             raise exception
         except self.on_exceptions:
@@ -156,7 +158,6 @@ class log_on_error(LoggingDecorator):
 
             if self.reraise:
                 raise
-
 
 class log_exception(log_on_error):
 


### PR DESCRIPTION
Replacing `types.FunctionType` with `typing.Callable`; I'm unsure if you want all the swaps with `ParamSpec` and `TypeVar` or just to keep those as `Any`.